### PR TITLE
Correct html tag to dictate language

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 
 <meta charset=utf-8>


### PR DESCRIPTION
Added `lang="en"` to the html tag to pass accessibility checks.